### PR TITLE
Fix search view width overflow

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="columns is-mobile is-centered is-gapless">
-    <div class="column">
+    <div class="column" style="width: 100vw;">
       <section class="top">
         <b-loading :is-full-page="false" :active.sync="isLoading"></b-loading>
         <div v-if="!isLoading">


### PR DESCRIPTION
This is my attempt at fixing issue #2, since I was also experiencing it. Seems to happen when there are particularly long album names in the search view, at least in my experience.